### PR TITLE
Refactor tunable params

### DIFF
--- a/src/engines/lynx.hpp
+++ b/src/engines/lynx.hpp
@@ -99,19 +99,19 @@ public:
                 result.push_back({(double)MiddleGamePositionalTables(piece, square), (double)EndGamePositionalTables(piece, square)});
         }
 
-        // DoubledPawnPenalty.Add(result);
-        IsolatedPawnPenalty.Add(result);
-        OpenFileRookBonus.Add(result);
-        SemiOpenFileRookBonus.Add(result);
-        RookMobilityBonus.Add(result);
-        QueenMobilityBonus.Add(result);
-        SemiOpenFileKingPenalty.Add(result);
-        OpenFileKingPenalty.Add(result);
-        KingShieldBonus.Add(result);
-        BishopPairBonus.Add(result);
+        // DoubledPawnPenalty.add(result);
+        IsolatedPawnPenalty.add(result);
+        OpenFileRookBonus.add(result);
+        SemiOpenFileRookBonus.add(result);
+        RookMobilityBonus.add(result);
+        QueenMobilityBonus.add(result);
+        SemiOpenFileKingPenalty.add(result);
+        OpenFileKingPenalty.add(result);
+        KingShieldBonus.add(result);
+        BishopPairBonus.add(result);
 
-        PassedPawnBonus.Add(result);
-        BishopMobilityBonus.Add(result);
+        PassedPawnBonus.add(result);
+        BishopMobilityBonus.add(result);
 
         std::cout << result.size() << " == " << numParameters << std::endl;
         assert(result.size() == numParameters);

--- a/src/engines/lynx.hpp
+++ b/src/engines/lynx.hpp
@@ -38,18 +38,18 @@ TunableArray BishopMobilityBonus(
 
 const int base = 64 * 6 - 16; // PSQT but removing pawns from 1 and 8 rank
 static int numParameters = base +
-                                     // DoubledPawnPenalty.size
-                                     IsolatedPawnPenalty.size +
-                                     OpenFileRookBonus.size +
-                                     SemiOpenFileRookBonus.size +
-                                     RookMobilityBonus.size +
-                                     QueenMobilityBonus.size +
-                                     SemiOpenFileKingPenalty.size +
-                                     OpenFileKingPenalty.size +
-                                     BishopPairBonus.size +
-                                     KingShieldBonus.size +
-                                     (PassedPawnBonus.size - PassedPawnBonus.start - PassedPawnBonus.end) + // 6, removing 1 and 8 rank values
-                                     (BishopMobilityBonus.size - BishopMobilityBonus.start - BishopMobilityBonus.end); // 14, removing count 14
+                           // DoubledPawnPenalty.size
+                           IsolatedPawnPenalty.size +
+                           OpenFileRookBonus.size +
+                           SemiOpenFileRookBonus.size +
+                           RookMobilityBonus.size +
+                           QueenMobilityBonus.size +
+                           SemiOpenFileKingPenalty.size +
+                           OpenFileKingPenalty.size +
+                           BishopPairBonus.size +
+                           KingShieldBonus.size +
+                           (PassedPawnBonus.size - PassedPawnBonus.start - PassedPawnBonus.end) +            // 6, removing 1 and 8 rank values
+                           (BishopMobilityBonus.size - BishopMobilityBonus.start - BishopMobilityBonus.end); // 14, removing count 14
 ;
 
 class Lynx
@@ -135,107 +135,53 @@ public:
         return std::round(value);
     }
 
+    static void print_csharp_parameters(const parameters_t &parameters)
+    {
+        std::stringstream ss;
+        std::string name;
+
+        // name = NAME(DoubledPawnPenalty);
+        // DoubledPawnPenalty.to_json(parameters, ss, name);
+
+        name = NAME(IsolatedPawnPenalty);
+        IsolatedPawnPenalty.to_csharp(parameters, ss, name);
+
+        name = NAME(OpenFileRookBonus);
+        OpenFileRookBonus.to_csharp(parameters, ss, name);
+
+        name = NAME(SemiOpenFileRookBonus);
+        SemiOpenFileRookBonus.to_csharp(parameters, ss, name);
+
+        name = NAME(RookMobilityBonus);
+        RookMobilityBonus.to_csharp(parameters, ss, name);
+
+        name = NAME(QueenMobilityBonus);
+        QueenMobilityBonus.to_csharp(parameters, ss, name);
+
+        name = NAME(SemiOpenFileKingPenalty);
+        SemiOpenFileKingPenalty.to_csharp(parameters, ss, name);
+
+        name = NAME(OpenFileKingPenalty);
+        OpenFileKingPenalty.to_csharp(parameters, ss, name);
+
+        name = NAME(KingShieldBonus);
+        KingShieldBonus.to_csharp(parameters, ss, name);
+
+        name = NAME(BishopPairBonus);
+        BishopPairBonus.to_csharp(parameters, ss, name);
+
+        name = NAME(PassedPawnBonus);
+        PassedPawnBonus.to_csharp(parameters, ss, name);
+
+        name = NAME(BishopMobilityBonus);
+        BishopMobilityBonus.to_csharp(parameters, ss, name);
+
+        std::cout << ss.str() << std::endl;
+    }
+
     static void print_parameters(const parameters_t &parameters)
     {
-        int pieceValues[12];
-
-        for (int phase = 0; phase <= 1; ++phase)
-        {
-            if (phase == 0)
-                std::cout << "internal static readonly short[] MiddleGamePieceValues =\n[\n\t";
-
-            else
-                std::cout << "\ninternal static readonly short[] EndGamePieceValues =\n[\n\t";
-
-            // Pawns
-            {
-                int pawnSum = 0;
-
-                for (int square = 0; square < 48; ++square)
-                {
-                    pawnSum += parameters[square][phase];
-                }
-
-                auto average = (pawnSum / 48.0);
-
-                auto pieceIndex = phase * 6;
-                // pieceValues[pieceIndex] = PieceValue[phase * 5];
-                pieceValues[pieceIndex] = static_cast<int>(std::round(average));
-                std::cout << "+" << pieceValues[pieceIndex] << ", ";
-            }
-
-            for (int piece = 1; piece < 5; ++piece)
-            {
-                int sum = 0;
-
-                for (int square = 0; square < 64; ++square)
-                {
-                    sum += parameters[piece * 64 - 16 + square][phase]; // Substract 16 since we're only tuning 48 pawn values
-                }
-
-                auto average = (sum / 64.0);
-
-                auto pieceIndex = piece + phase * 6;
-                // pieceValues[pieceIndex] = PieceValue[piece + phase * 5];
-                pieceValues[pieceIndex] = static_cast<int>(std::round(average));
-                std::cout << "+" << pieceValues[pieceIndex] << ", ";
-            }
-
-            // Kings
-            auto kingIndex = 5 + phase * 6;
-            pieceValues[kingIndex] = 0;
-            std::cout << pieceValues[kingIndex] << ",\n\t";
-
-            for (int piece = 0; piece < 5; ++piece)
-            {
-                auto pieceIndex = piece + phase * 6;
-                std::cout << "-" << pieceValues[pieceIndex] << ", ";
-            }
-
-            std::cout << pieceValues[kingIndex] << "\n];\n";
-        }
-
-        std::string names[] = {"Pawn", "Knight", "Bishop", "Rook", "Queen", "King"};
-
-        // Pawns
-        {
-            const int piece = 0;
-            for (int phase = 0; phase <= 1; ++phase)
-            {
-                std::cout << "\ninternal static readonly short[] " << (phase == 0 ? "MiddleGame" : "EndGame") << names[piece] << "Table =\n[\n\t";
-
-                std::cout << "0,\t0,\t0,\t0,\t0,\t0,\t0,\t0,\n\t";
-                for (int square = 0; square < 48; ++square)
-                {
-                    std::cout << round(parameters[square][phase] - pieceValues[phase * 6]) << ", ";
-                    if (square % 8 == 7)
-                        std::cout << "\n";
-                    if (square != 63)
-                        std::cout << "\t";
-                }
-                std::cout << "0,\t0,\t0,\t0,\t0,\t0,\t0,\t0," << std::endl;
-
-                std::cout << "];\n";
-            }
-        }
-
-        for (int piece = 1; piece < 6; ++piece)
-        {
-            for (int phase = 0; phase <= 1; ++phase)
-            {
-                std::cout << "\ninternal static readonly short[] " << (phase == 0 ? "MiddleGame" : "EndGame") << names[piece] << "Table =\n[\n\t";
-                for (int square = 0; square < 64; ++square)
-                {
-                    std::cout << round(parameters[piece * 64 - 16 + square][phase] - pieceValues[piece + phase * 6]) << ", "; // We substract the 16 non-tuned pawn valeus
-                    if (square % 8 == 7)
-                        std::cout << "\n";
-                    if (square != 63)
-                        std::cout << "\t";
-                }
-                std::cout << "];\n";
-            }
-        }
-        std::cout << std::endl;
+        print_psqt(parameters);
 
         std::stringstream ss;
         std::string name;
@@ -291,6 +237,7 @@ public:
                   << std::endl;
     }
 };
+
 
 static inline parameters_t initialParameters = Lynx::get_initial_parameters();
 

--- a/src/engines/lynx.hpp
+++ b/src/engines/lynx.hpp
@@ -135,50 +135,6 @@ public:
         return std::round(value);
     }
 
-    static void print_csharp_parameters(const parameters_t &parameters)
-    {
-        std::stringstream ss;
-        std::string name;
-
-        // name = NAME(DoubledPawnPenalty);
-        // DoubledPawnPenalty.to_json(parameters, ss, name);
-
-        name = NAME(IsolatedPawnPenalty);
-        IsolatedPawnPenalty.to_csharp(parameters, ss, name);
-
-        name = NAME(OpenFileRookBonus);
-        OpenFileRookBonus.to_csharp(parameters, ss, name);
-
-        name = NAME(SemiOpenFileRookBonus);
-        SemiOpenFileRookBonus.to_csharp(parameters, ss, name);
-
-        name = NAME(RookMobilityBonus);
-        RookMobilityBonus.to_csharp(parameters, ss, name);
-
-        name = NAME(QueenMobilityBonus);
-        QueenMobilityBonus.to_csharp(parameters, ss, name);
-
-        name = NAME(SemiOpenFileKingPenalty);
-        SemiOpenFileKingPenalty.to_csharp(parameters, ss, name);
-
-        name = NAME(OpenFileKingPenalty);
-        OpenFileKingPenalty.to_csharp(parameters, ss, name);
-
-        name = NAME(KingShieldBonus);
-        KingShieldBonus.to_csharp(parameters, ss, name);
-
-        name = NAME(BishopPairBonus);
-        BishopPairBonus.to_csharp(parameters, ss, name);
-
-        name = NAME(PassedPawnBonus);
-        PassedPawnBonus.to_csharp(parameters, ss, name);
-
-        name = NAME(BishopMobilityBonus);
-        BishopMobilityBonus.to_csharp(parameters, ss, name);
-
-        std::cout << ss.str() << std::endl;
-    }
-
     static void print_parameters(const parameters_t &parameters)
     {
         print_psqt(parameters);
@@ -235,6 +191,95 @@ public:
 
         std::cout << ss.str() << std::endl
                   << std::endl;
+    }
+
+    static void print_csharp_parameters(const parameters_t &parameters)
+    {
+        std::stringstream ss;
+        std::string name;
+
+        // name = NAME(DoubledPawnPenalty);
+        // DoubledPawnPenalty.to_json(parameters, ss, name);
+
+        name = NAME(IsolatedPawnPenalty);
+        IsolatedPawnPenalty.to_csharp(parameters, ss, name);
+
+        name = NAME(OpenFileRookBonus);
+        OpenFileRookBonus.to_csharp(parameters, ss, name);
+
+        name = NAME(SemiOpenFileRookBonus);
+        SemiOpenFileRookBonus.to_csharp(parameters, ss, name);
+
+        name = NAME(RookMobilityBonus);
+        RookMobilityBonus.to_csharp(parameters, ss, name);
+
+        name = NAME(QueenMobilityBonus);
+        QueenMobilityBonus.to_csharp(parameters, ss, name);
+
+        name = NAME(SemiOpenFileKingPenalty);
+        SemiOpenFileKingPenalty.to_csharp(parameters, ss, name);
+
+        name = NAME(OpenFileKingPenalty);
+        OpenFileKingPenalty.to_csharp(parameters, ss, name);
+
+        name = NAME(KingShieldBonus);
+        KingShieldBonus.to_csharp(parameters, ss, name);
+
+        name = NAME(BishopPairBonus);
+        BishopPairBonus.to_csharp(parameters, ss, name);
+
+        name = NAME(PassedPawnBonus);
+        PassedPawnBonus.to_csharp(parameters, ss, name);
+
+        name = NAME(BishopMobilityBonus);
+        BishopMobilityBonus.to_csharp(parameters, ss, name);
+
+        std::cout << ss.str() << std::endl;
+    }
+
+    static void print_cpp_parameters(const parameters_t &parameters)
+    {
+        std::stringstream ss;
+        std::string name;
+
+        // name = NAME(DoubledPawnPenalty);
+        // DoubledPawnPenalty.to_json(parameters, ss, name);
+
+        name = NAME(IsolatedPawnPenalty);
+        IsolatedPawnPenalty.to_cpp(parameters, ss, name);
+
+        name = NAME(OpenFileRookBonus);
+        OpenFileRookBonus.to_cpp(parameters, ss, name);
+
+        name = NAME(SemiOpenFileRookBonus);
+        SemiOpenFileRookBonus.to_cpp(parameters, ss, name);
+
+        name = NAME(RookMobilityBonus);
+        RookMobilityBonus.to_cpp(parameters, ss, name);
+
+        name = NAME(QueenMobilityBonus);
+        QueenMobilityBonus.to_cpp(parameters, ss, name);
+
+        name = NAME(SemiOpenFileKingPenalty);
+        SemiOpenFileKingPenalty.to_cpp(parameters, ss, name);
+
+        name = NAME(OpenFileKingPenalty);
+        OpenFileKingPenalty.to_cpp(parameters, ss, name);
+
+        name = NAME(KingShieldBonus);
+        KingShieldBonus.to_cpp(parameters, ss, name);
+
+        name = NAME(BishopPairBonus);
+        BishopPairBonus.to_cpp(parameters, ss, name);
+        ss << "\n";
+
+        name = NAME(PassedPawnBonus);
+        PassedPawnBonus.to_cpp(parameters, ss, name);
+
+        name = NAME(BishopMobilityBonus);
+        BishopMobilityBonus.to_cpp(parameters, ss, name);
+
+        std::cout << ss.str() << std::endl;
     }
 };
 

--- a/src/engines/lynx_tunable.hpp
+++ b/src/engines/lynx_tunable.hpp
@@ -22,7 +22,7 @@ public:
         packed = S(_mg, _eg);
     }
 
-    void Add(parameters_t &parameters)
+    void add(parameters_t &parameters)
     {
         index = parameters.size();
         parameters.push_back({(double)_mg, (double)_eg});
@@ -64,7 +64,7 @@ public:
         }
     }
 
-    void Add(parameters_t &parameters)
+    void add(parameters_t &parameters)
     {
         index = parameters.size();
         for (int rank = 0 + start; rank < size - end; ++rank)

--- a/src/engines/lynx_tunable.hpp
+++ b/src/engines/lynx_tunable.hpp
@@ -39,6 +39,11 @@ public:
     {
         ss << "\tpublic TaperedEvaluationTerm " << name << " { get; set; } = new(" << round(parameters[index][0]) << "," << round(parameters[index][1]) << ");\n";
     }
+
+    void to_cpp(const parameters_t &parameters, std::stringstream &ss, const std::string &name)
+    {
+        ss << "TunableSingle " << name << "(" << round(parameters[index][0]) << ", " << round(parameters[index][1]) << ");\n";
+    }
 };
 
 class TunableArray
@@ -154,5 +159,62 @@ public:
         }
 
         ss << "\n\n";
+    }
+
+    void to_cpp(const parameters_t &parameters, std::stringstream &ss, const std::string &name)
+    {
+        ss << "TunableArray " << name << "(\n";
+        ss << "\tstd::vector<int>{";
+        for (int rank = 0; rank < start; ++rank)
+        {
+            ss << "0, ";
+        }
+
+        for (int rank = 0; rank < size - end - start; ++rank)
+        {
+            ss << round(parameters[index + rank][0]);
+            if (rank == size - 1)
+                ss << "},\n";
+            else
+                ss << ", ";
+        }
+
+        for (int rank = size - end; rank < size; ++rank)
+        {
+            ss << "0";
+            if (rank == size - 1)
+                ss << "},\n";
+            else
+                ss << ", ";
+        }
+
+        ss << "\tstd::vector<int>{";
+
+        for (int rank = 0; rank < start; ++rank)
+        {
+            ss << "0, ";
+        }
+
+        for (int rank = 0; rank < size - end - start; ++rank)
+        {
+            ss << round(parameters[index + rank][1]);
+            if (rank == size - 1)
+                ss << "},\n";
+            else
+                ss << ", ";
+        }
+
+        for (int rank = size - end; rank < size; ++rank)
+        {
+            ss << "0";
+            if (rank == size - 1)
+                ss << "},\n";
+            else
+                ss << ", ";
+        }
+
+        ss << "\t" << size << ",\n";
+        ss << "\t" << start << ",\n";
+        ss << "\t" << end << ");\n\n";
     }
 };

--- a/src/engines/lynx_tunable.hpp
+++ b/src/engines/lynx_tunable.hpp
@@ -1,0 +1,105 @@
+#include "../base.h"
+#include "../external/chess.hpp"
+#include <string>
+#include <cmath>
+
+#define NAME(a) #a;
+using i32 = int32_t;
+
+class TunableSingle
+{
+    i32 _mg;
+    i32 _eg;
+
+public:
+    i32 packed;
+    i32 index;
+    constexpr static i32 size = 1;
+
+    TunableSingle(const i32 mg, const i32 eg)
+        : _mg(mg), _eg(eg)
+    {
+        packed = S(_mg, _eg);
+    }
+
+    void Add(parameters_t &parameters)
+    {
+        index = parameters.size();
+        parameters.push_back({(double)_mg, (double)_eg});
+    }
+
+    void to_json(const parameters_t &parameters, std::stringstream &ss, const std::string &name)
+    {
+        ss << "\"" << name << "\": {\n"
+           << "\t\"MG\": " << round(parameters[index][0]) << ",\n"
+           << "\t\"EG\": " << round(parameters[index][1]) << "\n}";
+    }
+};
+
+class TunableArray
+{
+    std::vector<i32> _mg;
+    std::vector<i32> _eg;
+
+public:
+    std::vector<i32> packed;
+    i32 index;
+    i32 size;
+    i32 start;
+    i32 end;
+
+    TunableArray(const std::vector<i32> mg, const std::vector<i32> eg, i32 size)
+    {
+        TunableArray(mg, eg, size, 0, 0);
+    }
+
+    TunableArray(const std::vector<i32> mg, const std::vector<i32> eg, i32 size, i32 start, i32 end)
+        : _mg(mg), _eg(eg), size(size), start(start), end(end)
+    {
+        packed = std::vector<i32>(size);
+
+        for (int rank = 0 + start; rank < size - end; ++rank)
+        {
+            packed[rank] = S(mg[rank], eg[rank]);
+        }
+    }
+
+    void Add(parameters_t &parameters)
+    {
+        index = parameters.size();
+        for (int rank = 0 + start; rank < size - end; ++rank)
+        {
+            parameters.push_back({(double)_mg[rank], (double)_eg[rank]});
+        }
+    }
+
+    void to_json(const parameters_t &parameters, std::stringstream &ss, const std::string &name)
+    {
+        const std::string keyword = size == 8
+                                        ? "Rank"
+                                        : "Count";
+
+        ss << "\"" << name << "\": {\n";
+        for (int rank = 0; rank < start; ++rank)
+        {
+            ss << "\t\"" << keyword << rank << "\": {\n";
+            ss << "\t\t\"MG\": " << 0 << ",\n";
+            ss << "\t\t\"EG\": " << 0 << "\n\t},\n";
+        }
+
+        for (int rank = 0; rank < size - end - start; ++rank)
+        {
+            ss << "\t\"" << keyword << rank + start << "\": {\n";
+            ss << "\t\t\"MG\": " << round(parameters[index + rank][0]) << ",\n";
+            ss << "\t\t\"EG\": " << round(parameters[index + rank][1]) << "\n\t},\n";
+        }
+
+        for (int rank = size - end; rank < size; ++rank)
+        {
+            ss << "\t\"" << keyword << rank << "\": {\n";
+            ss << "\t\t\"MG\": " << 0 << ",\n";
+            ss << "\t\t\"EG\": " << 0 << "\n\t}\n";
+            ss << "}";
+        }
+    }
+};

--- a/src/engines/lynx_tunable.hpp
+++ b/src/engines/lynx_tunable.hpp
@@ -34,6 +34,11 @@ public:
            << "\t\"MG\": " << round(parameters[index][0]) << ",\n"
            << "\t\"EG\": " << round(parameters[index][1]) << "\n}";
     }
+
+    void to_csharp(const parameters_t &parameters, std::stringstream &ss, const std::string &name)
+    {
+        ss << "\tpublic TaperedEvaluationTerm " << name << " { get; set; } = new(" << round(parameters[index][0]) << "," << round(parameters[index][1]) << ");\n";
+    }
 };
 
 class TunableArray
@@ -101,5 +106,53 @@ public:
             ss << "\t\t\"EG\": " << 0 << "\n\t}\n";
             ss << "}";
         }
+    }
+
+    void to_csharp(const parameters_t &parameters, std::stringstream &ss, const std::string &name)
+    {
+        std::string variable_name;
+
+        if (size == 8)
+        {
+            variable_name = "TaperedEvaluationTermByRank";
+        }
+        else if (size == 15)
+        {
+            variable_name = "TaperedEvaluationTermByCount";
+        }
+        else if (size == 28)
+        {
+            variable_name = "TaperedEvaluationTermByLargeCount";
+        }
+        else
+        {
+            throw std::invalid_argument("wrong size provided: " + size);
+        }
+
+        ss << "\tpublic " << variable_name << " " << name << " { get; set; } = new(\n";
+        for (int rank = 0; rank < start; ++rank)
+        {
+            ss << "\t\tnew(0,0),\n";
+        }
+
+        for (int rank = 0; rank < size - end - start; ++rank)
+        {
+            ss << "\t\tnew(" << round(parameters[index + rank][0]) << "," << round(parameters[index + rank][1]) << ")";
+            if (rank == size - 1)
+                ss << ");";
+            else
+                ss << ",\n";
+        }
+
+        for (int rank = size - end; rank < size; ++rank)
+        {
+            ss << "\t\tnew(0,0)";
+            if (rank == size - 1)
+                ss << ");";
+            else
+                ss << ",\n";
+        }
+
+        ss << "\n\n";
     }
 };

--- a/src/tuner.cpp
+++ b/src/tuner.cpp
@@ -948,6 +948,7 @@ void Tuner::run(const std::vector<DataSource>& sources)
     }
 
     TuneEval::print_csharp_parameters(parameters);
+    TuneEval::print_cpp_parameters(parameters);
 
     thread_pool.stop();
 }

--- a/src/tuner.cpp
+++ b/src/tuner.cpp
@@ -947,5 +947,7 @@ void Tuner::run(const std::vector<DataSource>& sources)
         }
     }
 
+    TuneEval::print_csharp_parameters(parameters);
+
     thread_pool.stop();
 }


### PR DESCRIPTION
- [Group tunable params in `TunableSingle` and `TunableArray` wrappers](https://github.com/lynx-chess/texel-tuner/commit/c1180b0a1b4bec74c21b6eadfeb4331d6185e4e8)
- [Print tuned eval params in C# format at the end of the tuning session](https://github.com/lynx-chess/texel-tuner/commit/3c981dffdd67b5007a136d5413a8456d394fa034)
- [Print tuned eval params in C++ format at the end of the tuning session](https://github.com/lynx-chess/texel-tuner/commit/1b09e4824023de9d9a858acd746725a7c4321d14)

Printing PSQTs in C++ format is what would be left for a better used experience